### PR TITLE
Include github packages maven repository in snapshot builds

### DIFF
--- a/dist/starter/resources/archetypes/kubernetes-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/dist/starter/resources/archetypes/kubernetes-archetype/src/main/resources/archetype-resources/pom.xml
@@ -23,14 +23,6 @@
         <enabled>false</enabled>
       </snapshots>
     </repository>
-
-    <repository>
-      <id>oss-jfrog-snapshot</id>
-      <url>https://oss.jfrog.org/artifactory/oss-snapshot-local</url>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
-    </repository>
   </repositories>
   <dependencies>
     <dependency>
@@ -170,7 +162,46 @@
             </execution>
           </executions>
         </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>build-helper-maven-plugin</artifactId>
+          <version>3.2.0</version>
+          <executions>
+            <execution>
+              <id>is-snapshot-build</id>
+              <phase>validate</phase>
+              <goals>
+                <goal>regex-property</goal>
+              </goals>
+              <configuration>
+                <name>is.snapshot.build</name>
+                <value>${project.version}</value>
+                <regex>.*-SNAPSHOT</regex>
+                <replacement>true</replacement>
+                <failIfNoMatch>false</failIfNoMatch>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
       </plugins>
     </pluginManagement>
   </build>
+  <profiles>
+    <profile>
+      <id>snapshot-build</id>
+      <activation>
+        <property>
+          <name>is.snapshot.build</name>
+          <value>true</value>
+        </property>
+      </activation>
+      <repositories>
+        <repository>
+          <id>github</id>
+          <url>https://maven.pkg.github.com/vlingo/vlingo-platform</url>
+          <snapshots><enabled>true</enabled></snapshots>
+        </repository>
+      </repositories>
+    </profile>
+  </profiles>
 </project>


### PR DESCRIPTION
GitHub packages require authentication. It might be a small obstacle for new users as it requires them to [create and configure a personal access token](https://github.com/vlingo/vlingo-xoom-starter#building-snapshots).

On the other hand, we only need the GitHub Maven repository when building a snapshot version. Since most of the end-users will rely on stable releases, there's no need to include the snapshot repository for them.

@danilo-ambrosio since the pom file isn't processed as a template I came up with an alternative approach relying on Maven profiles. Let me know what you think.